### PR TITLE
[FOR-3] Added wrapper around JSON loadToMap to print the raw string before throwing error.

### DIFF
--- a/src/main/java/com/regalii/regaliator/utils/JSON.java
+++ b/src/main/java/com/regalii/regaliator/utils/JSON.java
@@ -23,6 +23,7 @@
 package com.regalii.regaliator.utils;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 
 import java.util.Map;
 
@@ -39,7 +40,12 @@ public class JSON {
     static public Object loadToMap(final String json) {
         final Gson gson = new Gson();
 
-        return gson.fromJson(json, Map.class);
+        try {
+            return gson.fromJson(json, Map.class);
+        }
+        catch (JsonSyntaxException e) {
+            throw new JsonSyntaxException(String.format("Expected a JSON string but got: \"%s\".", json), e);
+        }
     }
 
     static public Object[] getArray(final Object root) {


### PR DESCRIPTION
The Arcus Java SDK currently expects all server responses to be JSON strings that are parseable into object maps. This assumption does not always hold when things go awry, especially in the presence of middlemen services between the SDK client and Arcus.

When this occurs, it's very difficult to diagnose what's going wrong because the exception stack trace only shows the Gson error of being unable to parse _a_ string into valid JSON, but doesn't show _the_ actual non-JSON string, which could contain useful information from the server. This PR just enriches the exception message by providing the raw string.